### PR TITLE
Update components-core default version to 0.5.40

### DIFF
--- a/template/src/preset.js
+++ b/template/src/preset.js
@@ -21,7 +21,7 @@ export const globalInit = async () => {
   });
 
   const componentsCoreRemote = {
-    ...registry, remote: 'components-core', defaultVersion: '0.5.38'
+    ...registry, remote: 'components-core', defaultVersion: '0.5.40'
   };
 
   remoteLoaderPreset({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
将模板远程加载的 `components-core` 默认版本从 `0.5.38` 更新到最新发布的 `0.5.40`。

已核对：
- npm `latest` tag：`0.5.40`
- 私有源 `https://uc.fatalent.cn/packages/@kne-components/components-core/0.5.40/build/remoteEntry.js` 可访问

`0.5.39` / `0.5.40` 变更（SelectTableList）：
- 搜索按 `pagination.paramsType` 写入请求，GET 列表可带上搜索条件
- 分页默认开启、下拉加载与翻页保留 filter
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9889869-c5ad-4b2f-9889-45af13afbcce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9889869-c5ad-4b2f-9889-45af13afbcce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

