### PR TITLE
chore: bump components-core to 0.5.41 (@kne-template/example 0.1.16)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-template/example",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "libs example初始化模板",
   "scripts": {
     "init": "husky",

--- a/template/src/preset.js
+++ b/template/src/preset.js
@@ -21,7 +21,7 @@ export const globalInit = async () => {
   });
 
   const componentsCoreRemote = {
-    ...registry, remote: 'components-core', defaultVersion: '0.5.40'
+    ...registry, remote: 'components-core', defaultVersion: '0.5.41'
   };
 
   remoteLoaderPreset({


### PR DESCRIPTION
## Summary
- Bump template `components-core` `defaultVersion` `0.5.40` → `0.5.41`
- Bump package version `0.1.15` → `0.1.16` so npm can publish (republishing `0.1.15` fails and left registry stuck with `0.4.51`)

After merge, Publish workflow should release `@kne-template/example@0.1.16`; then `npm run init-example` will pick up the new preset.

## Test plan
- [ ] PR merges and Publish Npm Package succeeds for `0.1.16`
- [ ] `npm view @kne-template/example version` → `0.1.16`
- [ ] Fresh `npm run init-example` yields `example/src/preset.js` with `defaultVersion: '0.5.41'`


Made with [Cursor](https://cursor.com)